### PR TITLE
Fix building on modern systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GBAFIX := tools/gbafix/gbafix$(EXE)
 SALSA := tools/salsa/build/salsa$(EXE)
 
 CXXFLAGS := -fno-exceptions -fno-rtti -quiet
-CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -O2 -g3 #-fdwarf-bugfix
+CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -O2 -g3 -fdwarf-bugfix
 CPPFLAGS := -I tools/agbcc/include -iquote include -nostdinc -undef -D VERSION_$(GAME_VERSION) -D REVISION=$(GAME_REVISION) -D $(GAME_REGION) -D DEBUG=$(DEBUG) -D DISABLE_SOUND=$(DISABLE_SOUND)
 ASFLAGS  := -mcpu=arm7tdmi -mthumb-interwork -I asminclude -I include --defsym VERSION_$(GAME_VERSION)=1 --defsym REVISION=$(GAME_REVISION) --defsym $(GAME_REGION)=1 --defsym DEBUG=$(DEBUG) --defsym GAME_VERSION=$(GAME_VERSION) --defsym GAME_REVISION=$(GAME_REVISION) --defsym DISABLE_SOUND=$(DISABLE_SOUND)
 #### Files ####

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GBAFIX := tools/gbafix/gbafix$(EXE)
 SALSA := tools/salsa/build/salsa$(EXE)
 
 CXXFLAGS := -fno-exceptions -fno-rtti -quiet
-CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -O2 -g3 -fdwarf-bugfix
+CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -O2 -g3 #-fdwarf-bugfix
 CPPFLAGS := -I tools/agbcc/include -iquote include -nostdinc -undef -D VERSION_$(GAME_VERSION) -D REVISION=$(GAME_REVISION) -D $(GAME_REGION) -D DEBUG=$(DEBUG) -D DISABLE_SOUND=$(DISABLE_SOUND)
 ASFLAGS  := -mcpu=arm7tdmi -mthumb-interwork -I asminclude -I include --defsym VERSION_$(GAME_VERSION)=1 --defsym REVISION=$(GAME_REVISION) --defsym $(GAME_REGION)=1 --defsym DEBUG=$(DEBUG) --defsym GAME_VERSION=$(GAME_VERSION) --defsym GAME_REVISION=$(GAME_REVISION) --defsym DISABLE_SOUND=$(DISABLE_SOUND)
 #### Files ####
@@ -188,7 +188,7 @@ $(RODATA_ASM_BUILDDIR)/%.o: rodata_dep = $(shell $(SCANINC) -I include -I "" $(R
 endif
 
 #### Recipes ####
-   
+
 $(OBJ_DIR)/ld_script.ld: $(LDSCRIPT)
 	cp $(LDSCRIPT) $(OBJ_DIR)
 

--- a/tools/salsa/salsaTextDynamic.cpp
+++ b/tools/salsa/salsaTextDynamic.cpp
@@ -95,7 +95,7 @@ DynamicMessageBlock::DynamicMessageBlock(SalsaStream* stream, s32 messages_top, 
 
             // im letting these break on 0xFFFF, hopefully they dont overlap the above edge
             // cases
-            if (!message_headers[i + 1].is_duplicate) {
+            if (i + 1 < message_headers.size() && !message_headers[i + 1].is_duplicate) {
                 if (i != message_headers.size() - 1) {
                     msg_size = message_headers[i + 1].offset - message_off.offset;
                 } else {


### PR DESCRIPTION
Bounds check in salsaTextDynamic was missing, causing:
```
tools/salsa/build/salsa --extract baserom.gba assets/mainscript.salsa
/usr/include/c++/16/bits/stl_vector.h:1253: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = text::MessageHeader; _Alloc = std::allocator<text::MessageHeader>; reference = text::MessageHeader&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
make: *** [Makefile:202: setup] Aborted (core dumped)
```

~~Additionally, `agbcc: Invalid option '-fdwarf-bugfix'`. While I'm no C(++) developer, we get `mother3.gba: OK` without this, so I've commented it out. Perhaps someone smarter than me can explain whateverthehell that flag does.~~ Update: Looks like it depends on a specific version of AGBCC; that might be worth mentioning and also potentially worth mirroring the AGBCP build, since it's so old it expects an **i386** system.